### PR TITLE
Docker based CI

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,27 @@
+name: Docker CI
+
+on:  
+  push:
+  workflow_dispatch:
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push image
+      run: |
+        docker build --tag ghcr.io/nwchemex-project/parallelzone_gcc11 \
+                     --build-arg BASE_IMAGE=ghcr.io/nwchemex-project/parallelzone_gcc11 \
+                     --build-arg REPO_NAME=ParallelZone \
+                     --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+                     --build-arg BRANCH_NAME=${GITHUB_REF_NAME} .
+        docker push ghcr.io/nwchemex-project/parallelzone_gcc11 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG         GITHUB_TOKEN
 
 # ${BASE_IMAGE} should have the repo in /app/${REPO_NAME}
 WORKDIR     /app/${REPO_NAME}
-RUN         echo $PWD
+RUN         git pull 
 RUN         git checkout ${BRANCH_NAME}
 RUN         git pull 
 # Build...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# You can build this image by passing BASE_IMAGE, REPO_NAME, BRANCH_NAME, and GITHUB_TOKEN arguments:
+# docker build --platform linux/amd64 -t test_build \
+#                            --build-arg BASE_IMAGE=nwchemex-project/parallelzone_gcc11 \ 
+#                            --build-arg REPO_NAME=ParallelZone \
+#                            --build-arg BRANCH_NAME=master \
+#                            --build-arg GITHUB_TOKEN=XXX .
+
+ARG         BASE_IMAGE
+FROM        ${BASE_IMAGE}
+
+ARG         REPO_NAME
+ARG         BRANCH_NAME=master
+ARG         GITHUB_TOKEN
+
+# ${BASE_IMAGE} should have the repo in /app/${REPO_NAME}
+WORKDIR     /app/${REPO_NAME}
+RUN         echo $PWD
+RUN         git checkout ${BRANCH_NAME}
+RUN         git pull 
+# Build...
+RUN         cmake --build build
+WORKDIR     /app/${REPO_NAME}/build
+# Tests run faster with one thread.
+ENV         MAD_NUM_THREADS=1
+# OpenMPI requires these env vars
+ENV         OMPI_ALLOW_RUN_AS_ROOT=1
+ENV         OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+# Run the tests. This could be seperated from the build as well.
+RUN         ctest  -VV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2022 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # You can build this image by passing BASE_IMAGE, REPO_NAME, BRANCH_NAME, and GITHUB_TOKEN arguments:
 # docker build --platform linux/amd64 -t test_build \
 #                            --build-arg BASE_IMAGE=nwchemex-project/parallelzone_gcc11 \ 


### PR DESCRIPTION
This PR adds a `Dockerfile` and introduces Docker based CI as mentioned in the group meetings and earlier in the issue related to reducing build times (https://github.com/NWChemEx-Project/.github/issues/24, see the suggested solution 4). 

The Dockerfile is generic and can be used in all the other repos. Along with CI, it can help users to try ParallelZone in an isolated environment and also with [Codespaces](https://github.com/features/codespaces). 

The CI takes less than 3 minutes if a reconfigure is not triggered and updates the base image if the build and tests run successfully. The build and test could be separated, too. 

There might be two pitfalls with this approach. 
1.  Dependency updates may not be caught unless a reconfigure is triggered. A workaround could be running `touch CMakeLists.txt` to force a reconfigure. However, I'd argue that we should always follow a specific tag/commit for our dependencies, then we don't need any workarounds. It is annoying to find out a build fails because of an update in a dependency. 
2. GitHub might start charging for using their [registry](https://github.com/features/packages#pricing) for private repos. I think it is free now for promotion and hopefully stays free until we release our repos. 

There might be others as well, I just wanted to submit this PR to discuss if this idea is viable. If so, this can be generalized with the help of the CI team and be a part of `.github` repo.
