### PR TITLE
Revert "Remove madness world"

### DIFF
--- a/include/parallelzone/archive_wrapper.hpp
+++ b/include/parallelzone/archive_wrapper.hpp
@@ -29,9 +29,9 @@ using variant_input =
                parallelzone::JSONInputArchive*, parallelzone::XMLInputArchive*>;
 
 /** @brief ArchiveWrapper class enables serialization and deserialization of
- * objects using various types of archives supported by Cereal.
+ * objects using various types of archives supported by MADNESS and Cereal.
  *
- *  This class wraps Cereal API for different output archive types.
+ *  This class wraps MADNESS/Cereal API for different output archive types.
  * Required for serialization of Any.
  */
 template<typename VariantArchive>
@@ -42,6 +42,8 @@ public:
 
     template<typename T>
     ArchiveWrapper& operator()(T&& obj) {
+        // MADNESS archive doesn't support `()`, but it supports `&` like Boost
+        // archive.
         std::visit([&](auto&& ar) { (*ar) & std::forward<T>(obj); }, m_ar_);
         return *this;
     }

--- a/include/parallelzone/mpi_helpers/commpp/commpp.hpp
+++ b/include/parallelzone/mpi_helpers/commpp/commpp.hpp
@@ -15,7 +15,6 @@
  */
 
 #pragma once
-#include <memory>
 #include <mpi.h>
 #include <parallelzone/mpi_helpers/binary_buffer/binary_buffer.hpp>
 #include <parallelzone/mpi_helpers/binary_buffer/binary_view.hpp>

--- a/src/parallelzone/runtime/detail_/runtime_view_pimpl.hpp
+++ b/src/parallelzone/runtime/detail_/runtime_view_pimpl.hpp
@@ -21,7 +21,15 @@ namespace parallelzone::runtime::detail_ {
 
 /** @brief Holds the state for the RuntimeView class
  *
- *  This class uses CommPP to manage MPI.
+ *  Right now this class assumes MADNESS is managing MPI, so it holds a MADNESS
+ *  world; however, no part of ParallelZone actually uses the MADNESS world
+ *  and it is entirely possible to just power this class off of the CommPP
+ *  object.
+ *
+ *  One option going forward would be to make this class polymorphic and have
+ *  the derived classes power the RuntimeView based on the runtime the user
+ *  wants to use (e.g., one derived class if we want to use MADNESS, another
+ *  derived class for CommPP).
  *
  */
 struct RuntimeViewPIMPL {
@@ -44,6 +52,9 @@ struct RuntimeViewPIMPL {
     /// Type of the conatiner holding resource_set_type objects
     using resource_set_container = std::map<size_type, resource_set_type>;
 
+    /// Ultimately a typedef of RuntimeView::madness_world_reference
+    using madness_world_reference = parent_type::madness_world_reference;
+
     /// The type of our MPI Comm wrapper
     using comm_type = mpi_helpers::CommPP;
 
@@ -62,24 +73,26 @@ struct RuntimeViewPIMPL {
     /// Ultimately a typedef of RuntimeView::argv_type
     using argv_type = parent_type::argv_type;
 
-    /** @brief Initializes *this from the provided MPI communicator.
+    /** @brief Initializes *this from the provided MADNESS world.
      *
-     *  Constructor for the RuntimeViewPIMPL class.
+     *  This ctor will strip the relevant information off of the MADNESS world
+     *  to initialize *this (e.g., the rank of the current process, and the MPI
+     *  communicator). It also records whether or no *this is responsible for
+     *  tearing down MADNESS when it goes out of scope (if *this started
+     *  MADNESS then it is responsible for tearing it down).
      *
-     *  @param[in] did_i_start_commpp True if *this should be responsible for
-     *                                 the lifetime of CommPP and false
+     *  @param[in] did_i_start_madness True if *this should be responsible for
+     *                                 the lifetime of MADNESS and false
      *                                 otherwise.
-     *  @param[in] comm The MPI communicator associated with the instance of the
-     * class.
+     *  @param[in] world The MADNESS world *this wraps.
      *
      *  @param[in] logger The program-wide logger as seen by the current
      *                    process.
      */
-
-    RuntimeViewPIMPL(bool did_i_start_commpp, comm_type comm,
+    RuntimeViewPIMPL(bool did_i_start_madness, madness_world_reference world,
                      logger_type logger);
 
-    /// Destructor, when all references are gone (and if we started it)
+    /// Tears down MADNESS, when all references are gone (and if we started it)
     ~RuntimeViewPIMPL() noexcept;
 
     /** @brief Wraps retrieving a ResourceSet
@@ -118,8 +131,11 @@ struct RuntimeViewPIMPL {
      */
     bool operator==(const RuntimeViewPIMPL& rhs) const noexcept;
 
-    /// Did this PIMPL start CommPP?
-    bool m_did_i_start_commpp;
+    /// Did this PIMPL start MADNESS?
+    bool m_did_i_start_madness;
+
+    /// Reference to the madness world this instance wraps
+    madness_world_reference m_world;
 
     /// The MPI communicator we're built around
     comm_type m_comm;

--- a/src/parallelzone/runtime/detail_/runtime_view_pimpl.ipp
+++ b/src/parallelzone/runtime/detail_/runtime_view_pimpl.ipp
@@ -25,10 +25,12 @@
 
 namespace parallelzone::runtime::detail_ {
 
-inline RuntimeViewPIMPL::RuntimeViewPIMPL(bool did_i_start_commpp,
-                                          comm_type comm, logger_type logger) :
-  m_did_i_start_commpp(did_i_start_commpp),
-  m_comm(comm),
+inline RuntimeViewPIMPL::RuntimeViewPIMPL(bool did_i_start_madness,
+                                          madness_world_reference world,
+                                          logger_type logger) :
+  m_did_i_start_madness(did_i_start_madness),
+  m_world(world),
+  m_comm(world.mpi.comm().Get_mpi_comm()),
   m_plogger(std::make_shared<logger_type>(std::move(logger))),
   m_resource_sets_() {
     // Pre-populate the current rank's resource set.
@@ -36,8 +38,8 @@ inline RuntimeViewPIMPL::RuntimeViewPIMPL(bool did_i_start_commpp,
 }
 
 inline RuntimeViewPIMPL::~RuntimeViewPIMPL() noexcept {
-    if(!m_did_i_start_commpp) return;
-    MPI_Finalize();
+    if(!m_did_i_start_madness) return;
+    madness::finalize();
 }
 
 inline RuntimeViewPIMPL::const_resource_set_reference RuntimeViewPIMPL::at(

--- a/src/parallelzone/runtime/runtime_view.cpp
+++ b/src/parallelzone/runtime/runtime_view.cpp
@@ -28,17 +28,25 @@ namespace parallelzone::runtime {
 namespace {
 
 // Basically a ternary statement dispatching on whether we need to initialize
-// MPI or not
-auto start_commpp(int argc, char** argv, const MPI_Comm& comm) {
-    int mpi_initialized;
-    MPI_Initialized(&mpi_initialized);
-    if(!mpi_initialized) { MPI_Init(&argc, &argv); }
-    mpi_helpers::CommPP commpp(comm);
+// MADNESS or not
+auto start_madness(int argc, char** argv, const MPI_Comm& comm) {
+    bool initialize = !madness::initialized();
+    madness::World* pworld;
+    if(initialize) {
+        // MADNESS doesn't appear to check if the provided comm is
+        // MPI_COMM_WORLD, so if you pass an MPI_COMM it assumes MPI was
+        // initialized. This if/else statement avoids passing a comm if we were
+        // given MPI_COMM_WORLD
+        if(comm == MPI_COMM_WORLD)
+            pworld = &madness::initialize(argc, argv, true);
+        else
+            pworld = &madness::initialize(argc, argv, comm, true);
+    } else
+        pworld = madness::World::find_instance(SafeMPI::Intracomm(comm));
 
-    auto log         = LoggerFactory::default_global_logger(commpp.me());
+    auto log         = LoggerFactory::default_global_logger(pworld->rank());
     using pimpl_type = detail_::RuntimeViewPIMPL;
-    return std::make_shared<pimpl_type>(!mpi_initialized, commpp,
-                                        std::move(log));
+    return std::make_shared<pimpl_type>(initialize, *pworld, std::move(log));
 }
 
 } // namespace
@@ -54,8 +62,11 @@ RuntimeView::RuntimeView(argc_type argc, argv_type argv) :
 
 RuntimeView::RuntimeView(mpi_comm_type comm) : RuntimeView(0, nullptr, comm) {}
 
+RuntimeView::RuntimeView(madness_world_reference world) :
+  RuntimeView(0, nullptr, world.mpi.comm().Get_mpi_comm()) {}
+
 RuntimeView::RuntimeView(int argc, char** argv, mpi_comm_type comm) :
-  RuntimeView(start_commpp(argc, argv, comm)) {}
+  RuntimeView(start_madness(argc, argv, comm)) {}
 
 RuntimeView::RuntimeView(pimpl_pointer pimpl) noexcept :
   m_pimpl_(std::move(pimpl)) {}
@@ -76,17 +87,21 @@ RuntimeView::~RuntimeView() noexcept = default;
 
 RuntimeView::mpi_comm_type RuntimeView::mpi_comm() const noexcept {
     if(null()) return MPI_COMM_NULL;
-    return m_pimpl_->m_comm.comm();
+    return m_pimpl_->m_world.mpi.comm().Get_mpi_comm();
+}
+
+RuntimeView::madness_world_reference RuntimeView::madness_world() const {
+    return pimpl_().m_world;
 }
 
 RuntimeView::size_type RuntimeView::size() const noexcept {
-    return !null() ? m_pimpl_->m_comm.size() : 0;
+    return !null() ? madness_world().size() : 0;
 }
 
 bool RuntimeView::null() const noexcept { return !static_cast<bool>(m_pimpl_); }
 
-bool RuntimeView::did_i_start_commpp() const noexcept {
-    return !null() ? m_pimpl_->m_did_i_start_commpp : false;
+bool RuntimeView::did_i_start_madness() const noexcept {
+    return !null() ? m_pimpl_->m_did_i_start_madness : false;
 }
 
 RuntimeView::const_resource_set_reference RuntimeView::at(size_type i) const {

--- a/tests/cxx/unit_tests/parallelzone/runtime/runtime_view.cpp
+++ b/tests/cxx/unit_tests/parallelzone/runtime/runtime_view.cpp
@@ -27,8 +27,8 @@ using namespace runtime;
 /* Testing notes
  *
  * Here we have similar caveats to the RuntimeViewPIMPL unit tests, namely we
- * need to avoid restarting and/or shutting down CommPP (and MPI under it). By
- * time we get into this test the main function will have initialized CommPP by
+ * need to avoid restarting and/or shutting down MADNESS (and MPI under it). By
+ * time we get into this test the main function will have initialized MADNESS by
  * calling the RuntimeView(argc_type, argv_type) ctor.
  *
  * These unit tests assume MPI_COMM_WORLD is the top-level communicator given
@@ -49,16 +49,20 @@ TEST_CASE("RuntimeView") {
         SECTION("Default") {
             REQUIRE(defaulted.size() > 0);
             REQUIRE(defaulted.mpi_comm() == MPI_COMM_WORLD);
-            REQUIRE_FALSE(defaulted.did_i_start_commpp());
+            REQUIRE_FALSE(defaulted.did_i_start_madness());
         }
         SECTION("argc and argv") {
             REQUIRE(argc_argv.size() > 0);
             REQUIRE(argc_argv.mpi_comm() == MPI_COMM_WORLD);
-            REQUIRE(argc_argv.did_i_start_commpp());
+            REQUIRE(argc_argv.did_i_start_madness());
         }
         SECTION("mpi comm") {
             RuntimeView mpi_comm(argc_argv.mpi_comm());
             REQUIRE(mpi_comm == argc_argv);
+        }
+        SECTION("madness world") {
+            RuntimeView mad_world(argc_argv.madness_world());
+            REQUIRE(mad_world == argc_argv);
         }
         SECTION("primary") {
             RuntimeView primary(0, nullptr, argc_argv.mpi_comm());
@@ -148,16 +152,20 @@ TEST_CASE("RuntimeView") {
         REQUIRE(result == MPI_IDENT);
     }
 
+    SECTION("madness_world") {
+        REQUIRE_THROWS_AS(null.madness_world(), std::runtime_error);
+    }
+
     SECTION("size()") {
         REQUIRE(null.size() == 0);
         REQUIRE(defaulted.size() > 0);
         REQUIRE(argc_argv.size() > 0);
     }
 
-    SECTION("did_i_start_commpp") {
-        REQUIRE_FALSE(null.did_i_start_commpp());
-        REQUIRE_FALSE(defaulted.did_i_start_commpp());
-        REQUIRE(argc_argv.did_i_start_commpp());
+    SECTION("did_i_start_madness") {
+        REQUIRE_FALSE(null.did_i_start_madness());
+        REQUIRE_FALSE(defaulted.did_i_start_madness());
+        REQUIRE(argc_argv.did_i_start_madness());
     }
 
     SECTION("at()") {


### PR DESCRIPTION
Reverts NWChemEx-Project/ParallelZone#101

The last PR should have left the initialize/finalize to MADNESS in place too (not just the CMakeLists.txt)